### PR TITLE
Simple fix to stop errors if the list is empty

### DIFF
--- a/pyryx.py
+++ b/pyryx.py
@@ -63,7 +63,7 @@ class PyRyxApi:
         if (len(result_list) > 1):
             df = pd.concat(result_list)
         else:
-            df = result_list[0]
+            df = result_list[:1]
         return df[:-1]
 
 


### PR DESCRIPTION
for executeAndFetchResults